### PR TITLE
Add active power and energy measurement

### DIFF
--- a/include/mgos_ade7953.h
+++ b/include/mgos_ade7953.h
@@ -25,25 +25,35 @@ extern "C" {
 
 #include "mgos_i2c.h"
 
-#define MGOS_ADE7953_DEFAULT_I2CADDR (0x38)
-
 struct mgos_ade7953;
+
+struct mgos_ade7953_config {
+  // Scaling factor to convert voltage channel ADC readings to voltage.
+  // It depends on the parameters of the voltage divider used on the input.
+  float voltage_scale;
+  // Voltage measurement offset, volts.
+  float voltage_offset;
+
+  // Scaling factoris to convert current channel ADC readings to amperes.
+  // Depends on the shunt parameters.
+  float current_scale[2];
+  // Current measurement offsets, in amps.
+  float current_offset[2];
+
+  // Scaling factors to convert active power to watts.
+  float apower_scale[2];
+
+  // Scaling factors to convert active energy to watt-hours.
+  float aenergy_scale[2];
+};
 
 // Create an instance of the driver at the given I2C bus and address.
 // Returns a pointer to the object upon success, NULL otherwise.
-struct mgos_ade7953 *mgos_ade7953_create(struct mgos_i2c *i2c, uint8_t i2caddr);
+struct mgos_ade7953 *mgos_ade7953_create(struct mgos_i2c *i2c, const struct mgos_ade7953_config *cfg);
 
 // Write the detected voltage in Volts RMS in the *volts pointer.
 // Returns true on success, false otherwise.
 bool mgos_ade7953_get_voltage(struct mgos_ade7953 *dev, float *volts);
-
-// Set scaling factor for the current shunt on the given channel (0 or 1).
-// Returns true on success, false otherwise.
-bool mgos_ade7953_set_scale_current(struct mgos_ade7953 *dev, int channel, float scale);
-
-// Set scaling factor for the volotage divider over the VP/VN pins of the chip.
-// Returns true on success, false otherwise.
-bool mgos_ade7953_set_scale_voltage(struct mgos_ade7953 *dev, float scale);
 
 // Write the detected line frequency in Hertz to the *hertz pointer.
 // Returns true on success, false otherwise.
@@ -54,7 +64,18 @@ bool mgos_ade7953_get_frequency(struct mgos_ade7953 *dev, float *hertz);
 // Returns true on success, false otherwise.
 bool mgos_ade7953_get_current(struct mgos_ade7953 *dev, int channel, float *amperes);
 
-// CLean up the driver and return memory used for it.
+// Write the instantaneous active power value, in Watts, to *watts.
+bool mgos_ade7953_get_apower(struct mgos_ade7953 *dev, int channel, float *watts);
+
+// Write the accumulated active energy, in watt-hours, to *wh.
+// If reset is true, resets the accumulator.
+bool mgos_ade7953_get_aenergy(struct mgos_ade7953 *dev, int channel, bool reset, float *wh);
+
+// Advanced usage: functions to read/write ADE7953 registers.
+bool mgos_ade7953_read_reg(struct mgos_ade7953 *dev, uint16_t reg, bool is_signed, int32_t *val);
+bool mgos_ade7953_write_reg(struct mgos_ade7953 *dev, uint16_t reg, int32_t val);
+
+// Clean up the driver and return memory used for it.
 bool mgos_ade7953_destroy(struct mgos_ade7953 **dev);
 
 #ifdef __cplusplus

--- a/src/mgos_ade7953_internal.h
+++ b/src/mgos_ade7953_internal.h
@@ -39,6 +39,7 @@
 #define MGOS_ADE7953_REG_PERIOD 0x10E
 #define MGOS_ADE7953_REG_RESERVED 0x120
 #define MGOS_ADE7953_REG_VERSION 0x702
+#define MGOS_ADE7953_REG_EX_REF 0x800
 
 struct mgos_ade7953 {
   struct mgos_i2c *i2c;

--- a/src/mgos_ade7953_internal.h
+++ b/src/mgos_ade7953_internal.h
@@ -23,8 +23,24 @@
 #include "mgos.h"
 #include "mgos_i2c.h"
 
+#define MGOS_ADE7953_I2C_ADDR 0x38
+
 // Registers
 //
+#define MGOS_ADE7953_REG_LCYCMODE 0x004
+#define MGOS_ADE7953_REG_PGA_V 0x007
+#define MGOS_ADE7953_REG_PGA_IA 0x008
+#define MGOS_ADE7953_REG_PGA_IB 0x009
+#define MGOS_ADE7953_REG_UNNAMED 0x0FE
+
+#define MGOS_ADE7953_REG_LINECYC 0x101
+#define MGOS_ADE7953_REG_CONFIG 0x102
+#define MGOS_ADE7953_REG_PERIOD 0x10E
+#define MGOS_ADE7953_REG_RESERVED 0x120
+
+#define MGOS_ADE7953_REG_AIRMSOS 0x386
+#define MGOS_ADE7953_REG_VRMSOS 0x388
+#define MGOS_ADE7953_REG_BIRMSOS 0x392
 #define MGOS_ADE7953_REG_AVA 0x310
 #define MGOS_ADE7953_REG_BVA 0x311
 #define MGOS_ADE7953_REG_AWATT 0x312
@@ -34,19 +50,17 @@
 #define MGOS_ADE7953_REG_IA 0x31A
 #define MGOS_ADE7953_REG_IB 0x31B
 #define MGOS_ADE7953_REG_V 0x31C
-#define MGOS_ADE7953_REG_UNNAMED 0x0FE
-#define MGOS_ADE7953_REG_CONFIG 0x102
-#define MGOS_ADE7953_REG_PERIOD 0x10E
-#define MGOS_ADE7953_REG_RESERVED 0x120
+#define MGOS_ADE7953_REG_ANENERGYA 0x31E
+#define MGOS_ADE7953_REG_ANENERGYB 0x31F
+
 #define MGOS_ADE7953_REG_VERSION 0x702
 #define MGOS_ADE7953_REG_EX_REF 0x800
 
 struct mgos_ade7953 {
   struct mgos_i2c *i2c;
-  uint8_t i2caddr;
 
   float voltage_scale;
   float current_scale[2];
+  float apower_scale[2];
+  float aenergy_scale[2];
 };
-
-bool mgos_ade7953_i2c_init(void);


### PR DESCRIPTION
Created a config struct to pass various scaling factors at creation time.
    
I suspect scaling factors can be derived from voltage and current factors
and/or internal constants of the chip but I just couldn't figure it out,
so for now passing them externally.
    
Hide I2C address, it cannot be anything other than 0x38 anyway.
Expose register read/write functions for advanced usage.

Fix signed reads < 32-bit registers