### PR TITLE
Add SPI bus support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This is a driver for Analog Devices [ADE7953](docs/ADE7953.pdf).
 
+## Bus selection
+
+Communication over I2C and SPI is supported, with I2C enabled by default. Bus
+support can be selected/deselected using defines:
+
+```
+cdefs:
+  MGOS_ADE7953_ENABLE_SPI: 1
+  MGOS_ADE7953_ENABLE_I2C: 0
+```
+
 ## Sensor details
 
 The ADE7953 is a high accuracy electrical energy measurement

--- a/include/mgos_ade7953.h
+++ b/include/mgos_ade7953.h
@@ -23,7 +23,6 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "mgos_i2c.h"
 
 struct mgos_ade7953;
 
@@ -47,9 +46,18 @@ struct mgos_ade7953_config {
   float aenergy_scale[2];
 };
 
+#if MGOS_ADE7953_ENABLE_I2C
 // Create an instance of the driver at the given I2C bus and address.
 // Returns a pointer to the object upon success, NULL otherwise.
-struct mgos_ade7953 *mgos_ade7953_create(struct mgos_i2c *i2c, const struct mgos_ade7953_config *cfg);
+#include "mgos_i2c.h"
+struct mgos_ade7953 *mgos_ade7953_create_i2c(struct mgos_i2c *i2c, const struct mgos_ade7953_config *cfg);
+#define mgos_ade7953_create mgos_ade7953_create_i2c
+#endif
+
+#if MGOS_ADE7953_ENABLE_SPI
+#include "mgos_spi.h"
+struct mgos_ade7953 *mgos_ade7953_create_spi(struct mgos_spi *spi, int cs, const struct mgos_ade7953_config *cfg);
+#endif
 
 // Write the detected voltage in Volts RMS in the *volts pointer.
 // Returns true on success, false otherwise.

--- a/mos.yml
+++ b/mos.yml
@@ -4,13 +4,29 @@ description: Mongoose OS library implementing an I2C driver for ADE7953
 version: 1.0
 
 sources:
-  - src
+  - src/mgos_ade7953.c
 
 includes:
   - include
 
-libs:
-  - origin: https://github.com/mongoose-os-libs/i2c
+conds:
+  - when: cdefs.MGOS_ADE7953_ENABLE_SPI == "1"
+    apply:
+      sources:
+        - src/mgos_ade7953_spi.c
+      libs:
+        - location: https://github.com/mongoose-os-libs/spi
+
+  - when: cdefs.MGOS_ADE7953_ENABLE_I2C == "1"
+    apply:
+      sources:
+        - src/mgos_ade7953_i2c.c
+      libs:
+        - location: https://github.com/mongoose-os-libs/i2c
+
+cdefs:
+  MGOS_ADE7953_ENABLE_SPI: 0
+  MGOS_ADE7953_ENABLE_I2C: 1
 
 tags:
   - c

--- a/src/mgos_ade7953_i2c.c
+++ b/src/mgos_ade7953_i2c.c
@@ -1,0 +1,55 @@
+#include "mgos_i2c.h"
+#include "mgos_ade7953.h"
+#include "mgos_ade7953_internal.h"
+
+struct mgos_ade7953 *mgos_ade7953_create_i2c(struct mgos_i2c *i2c, const struct mgos_ade7953_config *cfg) {
+  struct mgos_ade7953 *dev = { 0 };
+
+  if (!i2c) return NULL;
+  if (!(dev = calloc(1, sizeof(*dev)))) return NULL;
+  dev->i2c = i2c;
+
+  if (mgos_ade7953_create_common(dev, cfg)) {
+    return dev;
+  }
+  return NULL;
+}
+
+bool mgos_ade7953_write_reg_i2c(struct mgos_ade7953 *dev, uint16_t reg, int size, int32_t val) {
+  uint8_t data[6];
+  int i;
+
+  data[0] = (reg >> 8) & 0xff;
+  data[1] = reg & 0xff;
+
+  i = 2;
+  while (size--) {
+    data[i++] = (val >> (8 * size)) & 0xff;
+  }
+
+  if (!mgos_i2c_write(dev->i2c, MGOS_ADE7953_I2C_ADDR, data, i, true)) {
+    LOG(LL_ERROR, ("ADE7953 I2C write error (%d bytes)", i));
+    return false;
+  }
+  mgos_usleep(5);
+  return true;
+}
+
+bool mgos_ade7953_read_reg_i2c(struct mgos_ade7953 *dev, uint16_t reg, int size, uint8_t *val) {
+  uint8_t data[4];
+
+  data[0] = (reg >> 8) & 0xff;
+  data[1] = reg & 0xff;
+  if (!mgos_i2c_write(dev->i2c, MGOS_ADE7953_I2C_ADDR, data, 2, true)) {
+    LOG(LL_ERROR, ("ADE7953 I2C write error (2 bytes)"));
+    return false;
+  }
+  if (!mgos_i2c_read(dev->i2c, MGOS_ADE7953_I2C_ADDR, data, size, true)) {
+    LOG(LL_ERROR, ("ADE7953 I2C read8 error (%d bytes)", size));
+    return false;
+  }
+
+  memcpy(val, data, size);
+  return true;
+}
+

--- a/src/mgos_ade7953_internal.h
+++ b/src/mgos_ade7953_internal.h
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 #include "mgos.h"
-#include "mgos_i2c.h"
+#include "mgos_ade7953.h"
 
 #define MGOS_ADE7953_I2C_ADDR 0x38
 
@@ -57,10 +57,28 @@
 #define MGOS_ADE7953_REG_EX_REF 0x800
 
 struct mgos_ade7953 {
+#if MGOS_ADE7953_ENABLE_I2C
   struct mgos_i2c *i2c;
+#endif
+#if  MGOS_ADE7953_ENABLE_SPI
+  struct mgos_spi *spi;
+  int spi_cs;
+#endif
 
   float voltage_scale;
   float current_scale[2];
   float apower_scale[2];
   float aenergy_scale[2];
 };
+
+bool mgos_ade7953_create_common(struct mgos_ade7953 *dev, const struct mgos_ade7953_config *cfg);
+
+#if MGOS_ADE7953_ENABLE_I2C
+bool mgos_ade7953_write_reg_i2c(struct mgos_ade7953 *dev, uint16_t reg, int size, int32_t val);
+bool mgos_ade7953_read_reg_i2c(struct mgos_ade7953 *dev, uint16_t reg, int size, uint8_t *val);
+#endif
+
+#if  MGOS_ADE7953_ENABLE_SPI
+bool mgos_ade7953_write_reg_spi(struct mgos_ade7953 *dev, uint16_t reg, int size, int32_t val);
+bool mgos_ade7953_read_reg_spi(struct mgos_ade7953 *dev, uint16_t reg, int size, uint8_t *val);
+#endif

--- a/src/mgos_ade7953_spi.c
+++ b/src/mgos_ade7953_spi.c
@@ -1,0 +1,83 @@
+#include "mgos_spi.h"
+#include "mgos_ade7953.h"
+#include "mgos_ade7953_internal.h"
+
+struct mgos_ade7953 *mgos_ade7953_create_spi(struct mgos_spi *spi, int cs, const struct mgos_ade7953_config *cfg) {
+  struct mgos_ade7953 *dev = { 0 };
+
+  if (!spi) return NULL;
+  if (!(dev = calloc(1, sizeof(*dev)))) return NULL;
+  dev->spi = spi;
+
+  if (mgos_ade7953_create_common(dev, cfg)) {
+    return dev;
+  }
+  return NULL;
+}
+
+bool mgos_ade7953_write_reg_spi(struct mgos_ade7953 *dev, uint16_t reg, int size, int32_t val) {
+  uint8_t data_out[7];
+  int i;
+
+  if (!dev || size > 4 || size < 0) return false;
+
+  data_out[0] = (reg >> 8) & 0xff;
+  data_out[1] = reg & 0xff;
+  data_out[2] = 0x00;
+
+  i = 3;
+  while (size--) {
+    data_out[i++] = (val >> (8 * size)) & 0xff;
+  }
+
+  struct mgos_spi_txn txn = {
+    .cs = dev->spi_cs,
+    .mode = 3,
+    .freq = 1e6,
+    .hd = {
+      .tx_data = data_out,
+      .tx_len = 7,
+      .dummy_len = 0,
+      .rx_data = NULL,
+      .rx_len = 0,
+    },
+  };
+
+  bool res = mgos_spi_run_txn(dev->spi, false /* full-duplex */, &txn);
+  if (!res) {
+    LOG(LL_ERROR, ("write_reg failed!"));
+    return false;
+  }
+
+  return true;
+}
+
+bool mgos_ade7953_read_reg_spi(struct mgos_ade7953 *dev, uint16_t reg, int size, uint8_t *val) {
+  uint8_t data_out[3];
+
+  data_out[0] = (reg >> 8) & 0xff;
+  data_out[1] = reg & 0xff;
+  data_out[2] = 0x80;
+
+  struct mgos_spi_txn txn = {
+    .cs = dev->spi_cs,
+    .mode = 3,
+    .freq = 1e6,
+    .hd = {
+      .tx_data = data_out,
+      .tx_len = 3,
+      .dummy_len = 0,
+      .rx_data = val,
+      .rx_len = size,
+    },
+  };
+
+  bool res = mgos_spi_run_txn(dev->spi, false /* full-duplex */, &txn);
+  if (!res) {
+    LOG(LL_ERROR, ("read_reg failed!"));
+    return false;
+  }
+
+  return true;
+}
+


### PR DESCRIPTION
This changeset adds SPI bus support to the driver and allows for selectively linking I2C and SPI code.

There is a public API change: `mgos_ade7953_create()` becomes `mgos_ade7953_create_i2c()`