### PR TITLE
Fix power factor calculation

### DIFF
--- a/src/mgos_ade7953.c
+++ b/src/mgos_ade7953.c
@@ -241,12 +241,11 @@ bool mgos_ade7953_get_pf(struct mgos_ade7953 *dev, int channel, float *pf) {
     reg = MGOS_ADE7953_REG_PFB;
   else
     return false;
-  if (!mgos_ade7953_read_reg(dev, reg, true, &val)) {
+  if (!mgos_ade7953_read_reg(dev, reg, false, &val)) {
     return false;
   }
-  // bit 31 of val determines the sign, bits [0:30] represent the absolute part
-  // 2^-15 = 0.000030518
-  *pf = (val & (1 << 31)) ? /*negative sign*/ -((val & ~(1 << 31)) * 0.000030518) : /*positive sign*/ (val * 0.000030518);
+  // bit 15 is indicationg the sign and is part of the calculation
+  *pf = (val & (1 << 15)) ? /*negative sign*/ -(32767.0 / val) : /*positive sign*/ (val * 0.000030518);
   return true;
 }
 


### PR DESCRIPTION
According to specifications for the ADE7953, the power factor can
be positive (less than 1 is inductive load) and negative (less
than 1 is capacitive load). The value for a pure resistive load
representing 1 is 0x7fff, everything below this value is a power
factor < 1 and indication for inductive load. Everything above
0x7fff is again less than one, but it is negative and is indication
for capacitive load. In order to achive this - the calculation is
changed. When the value is greater than 0x7fff, eg. 0x800E the
returned value should be -0.999, this is done by -(0x7fff/0x800E)
When the value is below the 0x7fff, eg 0x7f36, the calculation
is 0x7fff/0x7f36. This way the returned value is in the range
of 0 to 1 and with sign representing the type of load connected.